### PR TITLE
Add HTTP headers property to WS and WSRequest

### DIFF
--- a/ws/WS.swift
+++ b/ws/WS.swift
@@ -41,6 +41,7 @@ public class WS {
     
     public var baseURL = ""
     public var OAuthToken: String?
+    public var headers = [String: String]()
     
     /**
      Create a webservice instance.
@@ -69,6 +70,7 @@ public class WS {
         if let token = OAuthToken {
             r.OAuthToken = token
         }
+        r.headers = headers
         return r
     }
     

--- a/ws/WSRequest.swift
+++ b/ws/WSRequest.swift
@@ -25,6 +25,7 @@ public class WSRequest {
     public var params = [String:AnyObject]()
     public var returnsJSON = true
     public var OAuthToken: String?
+    public var headers = [String: String]()
     public var fullURL:String { return baseURL + URL}
     public var timeout:NSTimeInterval?
     public var logLevels = WSLogLevel.None
@@ -46,6 +47,9 @@ public class WSRequest {
             if logLevels != .None {
                 print("TOKEN :\(token)")
             }
+        }
+        for (key, value) in headers {
+            r.setValue(value, forHTTPHeaderField: key)
         }
         if let t = self.timeout {
             r.timeoutInterval = t


### PR DESCRIPTION
In response to #10, this pull request adds a `headers` property to `WS`. The headers are then propagated to each `WSRequest` in `buildRequest()`.

Usage:

```
let ws = WS("https://myapi.com/data/v1/")
ws.headers["X-API-Key"] = "AABBCCDDEEFF11223344556677889900"
ws.headers["X-Client-Id"] = "MyMobileClient"
...
```
