### PR TITLE
Add CocoaPods Podspec

### DIFF
--- a/ws.podspec
+++ b/ws.podspec
@@ -1,0 +1,23 @@
+
+Pod::Spec.new do |s|
+    
+    s.name             = "ws"
+    s.version          = "1.2.1"
+    s.summary          = "Elegant JSON WebService for Swift ☁️"
+    
+    s.homepage         = "https://github.com/s4cha/ws"
+    s.license          = { :type => "MIT", :file => "LICENSE" }
+    s.author           = "S4cha"
+    s.source           = { :git => "https://github.com/s4cha/ws.git", :tag => s.version.to_s }
+    
+    s.ios.deployment_target = "8.0"
+    
+    s.source_files = "ws/*.{h,m,swift}"
+
+    s.frameworks = "Foundation"
+    
+    s.dependency "Arrow"
+    s.dependency "thenPromise"
+    s.dependency "Alamofire"
+
+end

--- a/ws/WS+Rest.swift
+++ b/ws/WS+Rest.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import Arrow
-import then
+import thenPromise
 
 extension WS {
 

--- a/ws/WS+TypedCalls.swift
+++ b/ws/WS+TypedCalls.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import Arrow
-import then
+import thenPromise
 
 
 extension WS {

--- a/ws/WS.swift
+++ b/ws/WS.swift
@@ -10,7 +10,7 @@
 import Foundation
 import Alamofire
 import Arrow
-import then
+import thenPromise
 
 var kWSJsonParsingSingleResourceKey:String? = nil
 var kWSJsonParsingColletionKey:String? = nil

--- a/ws/WSRequest.swift
+++ b/ws/WSRequest.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import Alamofire
-import then
+import thenPromise
 import Arrow
 
 public class WSRequest {


### PR DESCRIPTION
Hi Sacha. This pull request adds support for CocoaPods. I had to rename `import then` to `import thenPromise`. I see you have the Cartfile locked to a specific commit...was this because of the renaming of `then`? If so, we should update that to the right version.

Thanks!
