### PR TITLE
Add status code and headers as parameters in response handler

### DIFF
--- a/ws/WS+TypedCalls.swift
+++ b/ws/WS+TypedCalls.swift
@@ -36,7 +36,7 @@ extension WS {
         c.params = params
         
         // Apply corresponding JSON mapper
-        return c.fetch().registerThen { json -> T in
+        return c.fetch().registerThen { (json: JSON) -> T in
             let mapper = WSModelJSONParser<T>()
             let model = mapper.toModel(json)
             return model

--- a/ws/WS.swift
+++ b/ws/WS.swift
@@ -76,7 +76,7 @@ public class WS {
     //MARK: - Calls
     
     public func get<T:ArrowParsable>(url:String, params:[String:AnyObject] = [String:AnyObject]()) -> Promise<[T]> {
-        return getRequest(url, params: params).fetch().registerThen { json -> [T] in
+        return getRequest(url, params: params).fetch().registerThen { (json: JSON) -> [T] in
             let mapper = WSModelJSONParser<T>()
             let models = mapper.toModels(json)
             return models
@@ -106,25 +106,25 @@ public class WS {
     public func get(url:String, params:[String:AnyObject] = [String:AnyObject]()) -> Promise<Void> {
         let r = getRequest(url, params: params)
         r.returnsJSON = false
-        return r.fetch().registerThen { json -> Void in }
+        return r.fetch().registerThen { (json: JSON) -> Void in }
     }
     
     public func post(url:String, params:[String:AnyObject] = [String:AnyObject]()) -> Promise<Void> {
         let r = postRequest(url, params: params)
         r.returnsJSON = false
-        return r.fetch().registerThen { json -> Void in }
+        return r.fetch().registerThen { (json: JSON) -> Void in }
     }
     
     public func put(url:String, params:[String:AnyObject] = [String:AnyObject]()) -> Promise<Void> {
         let r = putRequest(url, params: params)
         r.returnsJSON = false
-        return r.fetch().registerThen { _ -> Void in }
+        return r.fetch().registerThen { (_: JSON) -> Void in }
     }
     
     public func delete(url:String, params:[String:AnyObject] = [String:AnyObject]()) -> Promise<Void> {
         let r = deleteRequest(url, params: params)
         r.returnsJSON = false
-        return r.fetch().registerThen { _ -> Void in }
+        return r.fetch().registerThen { (_: JSON) -> Void in }
     }
     
     //MARK: - Multipart
@@ -146,7 +146,7 @@ public class WS {
         c.URL = url
         c.params = params
         // Apply corresponding JSON mapper
-        return c.fetch().registerThen { json -> [T] in
+        return c.fetch().registerThen { (json: JSON) -> [T] in
             let mapper = WSModelJSONParser<T>()
             let models = mapper.toModels(json)
             return models

--- a/wsTests/wsTests.swift
+++ b/wsTests/wsTests.swift
@@ -89,6 +89,15 @@ class wsTests: XCTestCase {
         waitForExpectationsWithTimeout(10, handler: nil)
     }
     
+    func testResponse() {
+        let exp = expectationWithDescription("")
+        ws.getRequest("/users").fetch().then { (statusCode, responseHeaders, json) in
+            XCTAssertEqual(statusCode, 200)
+            exp.fulfill()
+        }
+        waitForExpectationsWithTimeout(10, handler: nil)
+    }
+    
     // Here is typically how you would define an api endpoint.
     // aka latestUsers is a GET on /users and I should get back User objects
     func latestUsers() -> Promise<[User]> {


### PR DESCRIPTION
Response status code and headers are made available for `WSRequest` fetch handler along with JSON:

``` swift
ws.getRequest("/users").fetch().then { (statusCode, responseHeaders, json) in

}
```

Is is sometimes required to have response headers available when getting data from server. For example, `Etag` and `Last-Modified` values need to be accessed for long polling.
## 

The only downside to this addition is that it is now required to explicitly state which `fetch()` specialization you want to use:

``` swift
// use this
request.fetch().then { (json: JSON) -> Void in }

// instead of this
request.fetch().then { json -> Void in }
```

But because accessing the `WSRequest` and its `fetch()` function directly is a rather rare use-case, I think it's totally acceptable.
