### PR TITLE
Adds a default collection parsing keypath

### DIFF
--- a/ws/WS+TypedCalls.swift
+++ b/ws/WS+TypedCalls.swift
@@ -12,17 +12,12 @@ import then
 
 
 extension WS {
-
+    
     public func get<T:ArrowParsable>(_ url: String, params: [String: Any] = [String: Any](), keypath: String? = nil) -> Promise<[T]> {
+        let keypath = keypath ?? defaultCollectionParsingKeyPath
         return getRequest(url, params: params).fetch().registerThen { (json: JSON) -> [T] in
-            var subJSON = json
-            if let k = keypath, !k.isEmpty, let j = json[k] {
-                subJSON = j
-            } else if let k = self.defaultCollectionParsingKeyPath, !k.isEmpty, let j = json[k] {
-                subJSON = j
-            }
-            return WSModelJSONParser<T>().toModels(subJSON)
-        }.resolveOnMainThread()
+            WSModelJSONParser<T>().toModels(json, keypath: keypath)
+            }.resolveOnMainThread()
     }
     
     public func get<T:ArrowParsable>(_ url: String, params: [String: Any] = [String: Any](), keypath: String? = nil) -> Promise<T> {
@@ -49,10 +44,7 @@ extension WS {
         
         // Apply corresponding JSON mapper
         return c.fetch().registerThen { (json: JSON) -> T in
-            if let k = keypath, !k.isEmpty, let j = json[k] {
-                return WSModelJSONParser<T>().toModel(j)
-            }
-            return WSModelJSONParser<T>().toModel(json)
+            return WSModelJSONParser<T>().toModel(json, keypath: keypath)
         }.resolveOnMainThread()
     }
 }

--- a/ws/WS+TypedCalls.swift
+++ b/ws/WS+TypedCalls.swift
@@ -15,8 +15,14 @@ extension WS {
 
     public func get<T:ArrowParsable>(_ url: String, params: [String: Any] = [String: Any](), keypath: String? = nil) -> Promise<[T]> {
         return getRequest(url, params: params).fetch().registerThen { (json: JSON) -> [T] in
-            WSModelJSONParser<T>().toModels(json, keypath: keypath)
-            }.resolveOnMainThread()
+            var subJSON = json
+            if let k = keypath, !k.isEmpty, let j = json[k] {
+                subJSON = j
+            } else if let k = self.defaultCollectionParsingKeyPath, !k.isEmpty, let j = json[k] {
+                subJSON = j
+            }
+            return WSModelJSONParser<T>().toModels(subJSON)
+        }.resolveOnMainThread()
     }
     
     public func get<T:ArrowParsable>(_ url: String, params: [String: Any] = [String: Any](), keypath: String? = nil) -> Promise<T> {
@@ -43,7 +49,10 @@ extension WS {
         
         // Apply corresponding JSON mapper
         return c.fetch().registerThen { (json: JSON) -> T in
-            return WSModelJSONParser<T>().toModel(json, keypath: keypath)
+            if let k = keypath, !k.isEmpty, let j = json[k] {
+                return WSModelJSONParser<T>().toModel(j)
+            }
+            return WSModelJSONParser<T>().toModel(json)
         }.resolveOnMainThread()
     }
 }

--- a/ws/WS.swift
+++ b/ws/WS.swift
@@ -19,9 +19,7 @@ open class WS {
         This is overidden by the per-request keypath if present.
      
      */
-    open var defaultCollectionParsingKeyPath:String? = nil {
-        didSet{ kWSDefaultCollectionParsingKeyPath = defaultCollectionParsingKeyPath }
-    }
+    open var defaultCollectionParsingKeyPath:String? = nil
     
     @available(*, unavailable, renamed:"defaultCollectionParsingKeyPath")
     open var jsonParsingColletionKey:String? = nil

--- a/ws/WS.swift
+++ b/ws/WS.swift
@@ -14,6 +14,20 @@ import then
 open class WS {
     
     /**
+        Instead of using the same keypath for every call eg: "collection",
+        this enables to use a default keypath for parsing collections.
+        This is overidden by the per-request keypath if present.
+     
+     */
+    open var defaultCollectionParsingKeyPath:String? = nil {
+        didSet{ kWSDefaultCollectionParsingKeyPath = defaultCollectionParsingKeyPath }
+    }
+    
+    @available(*, unavailable, renamed:"defaultCollectionParsingKeyPath")
+    open var jsonParsingColletionKey:String? = nil
+    
+    
+    /**
         Prints network calls to the console. 
         Values Available are .None, Calls and CallsAndResponses.
         Default is None

--- a/ws/WSModelJSONParser.swift
+++ b/ws/WSModelJSONParser.swift
@@ -9,22 +9,17 @@
 import Foundation
 import Arrow
 
-
-var kWSDefaultCollectionParsingKeyPath:String? = nil
-
 open class WSModelJSONParser<T:ArrowParsable> {
     
     public init() { }
     
-    open func toModel(_ json: JSON) -> T {
-        return resource(from: json)
+    open func toModel(_ json: JSON, keypath: String? = nil) -> T {
+        let data = resourceData(from: json, keypath: keypath)
+        return resource(from: data)
     }
     
-    open func toModels(_ json: JSON) -> [T] {
-        if let k = kWSDefaultCollectionParsingKeyPath, let j = json[k], let array = j.collection {
-            return array.map { resource(from: $0) }
-        }
-        guard let array = json.collection else {
+    open func toModels(_ json: JSON, keypath: String? = nil) -> [T] {
+        guard let array = resourceData(from: json, keypath: keypath).collection else {
             return [T]()
         }
         return array.map { resource(from: $0) }
@@ -35,4 +30,12 @@ open class WSModelJSONParser<T:ArrowParsable> {
         t.deserialize(json)
         return t
     }
+    
+    private func resourceData(from json: JSON, keypath: String?) -> JSON {
+        if let k = keypath, !k.isEmpty, let j = json[k] {
+            return j
+        }
+        return json
+    }
+    
 }

--- a/ws/WSModelJSONParser.swift
+++ b/ws/WSModelJSONParser.swift
@@ -9,17 +9,22 @@
 import Foundation
 import Arrow
 
+
+var kWSDefaultCollectionParsingKeyPath:String? = nil
+
 open class WSModelJSONParser<T:ArrowParsable> {
     
     public init() { }
     
-    open func toModel(_ json: JSON, keypath: String? = nil) -> T {
-        let data = resourceData(from: json, keypath: keypath)
-        return resource(from: data)
+    open func toModel(_ json: JSON) -> T {
+        return resource(from: json)
     }
     
-    open func toModels(_ json: JSON, keypath: String? = nil) -> [T] {
-        guard let array = resourceData(from: json, keypath: keypath).collection else {
+    open func toModels(_ json: JSON) -> [T] {
+        if let k = kWSDefaultCollectionParsingKeyPath, let j = json[k], let array = j.collection {
+            return array.map { resource(from: $0) }
+        }
+        guard let array = json.collection else {
             return [T]()
         }
         return array.map { resource(from: $0) }
@@ -30,12 +35,4 @@ open class WSModelJSONParser<T:ArrowParsable> {
         t.deserialize(json)
         return t
     }
-    
-    private func resourceData(from json: JSON, keypath: String?) -> JSON {
-        if let k = keypath, !k.isEmpty, let j = json[k] {
-            return j
-        }
-        return json
-    }
-    
 }


### PR DESCRIPTION
## Use case
When most of the api calls returning a collection of objects use the same key path, then the code to write those requests is very redundant.
For instance, in Yummypets near 50 requests are wrapped in a `"collection"` key path.

Thanks to a default collection parsing key, the **code becomes more concise**.

For readability's sake, the old `jsonParsingColletionKey` has been made unavailable and renamed to a more understandable `defaultCollectionParsingKeyPath` used like so :

```swift
ws.defaultCollectionParsingKeyPath = "collection"
```

## Reasons
Writing this keypath evertime is very **redundant**.

This used to be supported and removing this useful feature would break client code, and this **silently**, which is very dangerous.

This would also require people to write more code, which is against what we're trying to achieve ))


## Best of both worlds
Of course, the `defaultCollectionParsingKeyPath` is overriden if a keypath is passed per request.


This allows both default and per-request configuration, allowing best of both worlds.




