### PR TITLE
Improve network activity indicator management.

### DIFF
--- a/ws.xcodeproj/project.pbxproj
+++ b/ws.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		503461C01DCE0F16002144C3 /* Arrow.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 503461AF1DCE0EDC002144C3 /* Arrow.framework */; };
 		503461C11DCE0F1E002144C3 /* then.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 503461B91DCE0EE2002144C3 /* then.framework */; };
 		50E9DBA21DCCB2F800E8A896 /* mappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E9DBA11DCCB2F800E8A896 /* mappingTests.swift */; };
+		9924FCE51DD76B4100FFBB26 /* WSNetworkIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9924FCE41DD76B4100FFBB26 /* WSNetworkIndicator.swift */; };
 		996CAB941BF67A7C00931EAD /* ws.h in Headers */ = {isa = PBXBuildFile; fileRef = 996CAB931BF67A7C00931EAD /* ws.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		996CAB9B1BF67A7C00931EAD /* ws.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 996CAB901BF67A7C00931EAD /* ws.framework */; };
 		996CABA01BF67A7C00931EAD /* wsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 996CAB9F1BF67A7C00931EAD /* wsTests.swift */; };
@@ -138,6 +139,7 @@
 		503461A91DCE0EDC002144C3 /* Arrow.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Arrow.xcodeproj; path = Carthage/Checkouts/Arrow/Arrow.xcodeproj; sourceTree = "<group>"; };
 		503461B21DCE0EE2002144C3 /* then.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = then.xcodeproj; path = Carthage/Checkouts/then/then.xcodeproj; sourceTree = "<group>"; };
 		50E9DBA11DCCB2F800E8A896 /* mappingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = mappingTests.swift; sourceTree = "<group>"; };
+		9924FCE41DD76B4100FFBB26 /* WSNetworkIndicator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WSNetworkIndicator.swift; sourceTree = "<group>"; };
 		996CAB901BF67A7C00931EAD /* ws.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ws.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		996CAB931BF67A7C00931EAD /* ws.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ws.h; sourceTree = "<group>"; };
 		996CAB951BF67A7C00931EAD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -252,6 +254,7 @@
 				99E3EDDA1CB5A8A70042C854 /* WSError.swift */,
 				99E3EDDC1CB5A8E50042C854 /* WSHTTPVerb.swift */,
 				99E3EDD61CB5A1B80042C854 /* WSLogLevel.swift */,
+				9924FCE41DD76B4100FFBB26 /* WSNetworkIndicator.swift */,
 				996CAB951BF67A7C00931EAD /* Info.plist */,
 			);
 			path = ws;
@@ -485,6 +488,7 @@
 				99E3EDD91CB5A1DE0042C854 /* WSModelJSONParser.swift in Sources */,
 				99E3EDD71CB5A1B80042C854 /* WSLogLevel.swift in Sources */,
 				99E3EDDB1CB5A8A70042C854 /* WSError.swift in Sources */,
+				9924FCE51DD76B4100FFBB26 /* WSNetworkIndicator.swift in Sources */,
 				99E3EDE51CB5ACD50042C854 /* WS+Requests.swift in Sources */,
 				99CCC3111BF67C1500497064 /* WS.swift in Sources */,
 				99E3EDDD1CB5A8E50042C854 /* WSHTTPVerb.swift in Sources */,

--- a/ws/WSNetworkIndicator.swift
+++ b/ws/WSNetworkIndicator.swift
@@ -1,0 +1,44 @@
+//
+//  WSNetworkIndicator.swift
+//  ws
+//
+//  Created by Sacha Durand Saint Omer on 12/11/2016.
+//  Copyright © 2016 s4cha. All rights reserved.
+//
+
+import Foundation
+
+/**
+    Abstracts network activity indicator management.
+    - This only shows activity indicator for requests longer than 1 second, so that loader is not shown for quick requests.
+    - This also waits for 0.2 seconds before hiding the indicator in case other simultaneous requests
+    occur in order to avoid flickering.
+ 
+ */
+class WSNetworkIndicator: NSObject {
+    
+    static let shared = WSNetworkIndicator()
+    private var runningRequests = 0
+
+    func startRequest() {
+        runningRequests += 1
+        // For some unowned reason using scheduledTimer does not work in this case.
+        let timer = Timer(timeInterval: 1, target: self, selector: #selector(tick), userInfo: nil, repeats: false)
+        RunLoop.main.add(timer, forMode: RunLoopMode.commonModes)
+    }
+    
+    func stopRequest() {
+        runningRequests -= 1
+        // For some unowned reason using scheduledTimer does not work in this case.
+        let timer = Timer(timeInterval: 0.2, target: self, selector: #selector(tick), userInfo: nil, repeats: false)
+        RunLoop.main.add(timer, forMode: RunLoopMode.commonModes)
+    }
+    
+    func tick() {
+        let previousValue = UIApplication.shared.isNetworkActivityIndicatorVisible
+        let newValue = (runningRequests != 0)
+        if newValue != previousValue {
+            UIApplication.shared.isNetworkActivityIndicatorVisible = newValue
+        }
+    }
+}

--- a/ws/WSRequest.swift
+++ b/ws/WSRequest.swift
@@ -71,7 +71,7 @@ open class WSRequest {
         return Promise<(Int, [AnyHashable: Any], JSON)> { resolve, reject, progress in
             DispatchQueue.global(qos: DispatchQoS.QoSClass.default).async {
                 if self.showsNetworkActivityIndicator {
-                    UIApplication.shared.isNetworkActivityIndicatorVisible = true
+                    WSNetworkIndicator.shared.startRequest()
                 }
                 if self.logLevels != .none {
                     print("\(self.httpVerb) \(self.URL)")
@@ -128,7 +128,7 @@ open class WSRequest {
         self.req = request(self.buildRequest())
         let bgQueue = DispatchQueue.global(qos:DispatchQoS.QoSClass.default)
         req?.validate().response(queue: bgQueue) { response in
-            UIApplication.shared.isNetworkActivityIndicatorVisible = false
+            WSNetworkIndicator.shared.stopRequest()
             self.printResponseStatusCodeIfNeeded(response.response)
             if response.error == nil {
                 resolve((response.response?.statusCode ?? 0, response.response?.allHeaderFields ?? [:], JSON(1 as AnyObject)!))
@@ -147,9 +147,8 @@ open class WSRequest {
     }
     
     func handleJSONResponse(_ response:DataResponse<Any>, resolve:(_ result:(Int, [AnyHashable: Any], JSON))-> Void, reject:(_ error: Error) -> Void) {
-        UIApplication.shared.isNetworkActivityIndicatorVisible = false
+        WSNetworkIndicator.shared.stopRequest()
         printResponseStatusCodeIfNeeded(response.response)
-        
         switch response.result {
         case .success(let value):
             if logLevels == .callsAndResponses {


### PR DESCRIPTION
- This only shows activity indicator for requests longer than 1 second, so that loader is not shown for quick requests.
- This also waits for 0.2 seconds before hiding the indicator in case other simultaneous requests occur in order to avoid flickering.