### PR TITLE
Fix podspec dependencies

### DIFF
--- a/ws.podspec
+++ b/ws.podspec
@@ -10,8 +10,8 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "9.0"
     s.source_files = "ws/*.{h,m,swift}"
     s.frameworks = "Foundation"
-    s.dependency "Arrow" '3.0.3'
-    s.dependency "thenPromise" '2.0.2'
-    s.dependency "Alamofire" '4.0.1'
+    s.dependency 'Arrow', '~> 3.0'
+    s.dependency 'thenPromise', '~> 2.0'
+    s.dependency 'Alamofire', '~> 4.0'
     s.description  = "Elegant JSON WebService for Swift - Stop writing boilerplate JSON webservice code and focus on your awesome App instead"
 end


### PR DESCRIPTION
When using the latest version of **ws** directly from git, i.e.:
```ruby
pod 'ws', :git => 'https://github.com/freshOS/ws.git'
```
`pod install` produced the following error:
>[!] Unable to find a specification for `Arrow3.0.3` depended upon by `ws`

This edit should fix the issue :)