### PR TITLE
Fix multipart params parsing

### DIFF
--- a/ws/WSRequest.swift
+++ b/ws/WSRequest.swift
@@ -93,15 +93,19 @@ open class WSRequest {
                               progress:@escaping (Float) -> Void) {
         upload(multipartFormData: { formData in
             for (key, value) in self.params {
-                if let int = value as? Int {
-                    let str = "\(int)"
-                    if let d = str.data(using: String.Encoding.utf8) {
-                        formData.append(d, withName: key)
+                let str: String
+                switch value {
+                case let opt as Any?:
+                    if let v = opt {
+                        str = "\(v)"
+                    } else {
+                        continue
                     }
-                } else {
-                    if let str = value as? String, let data = str.data(using: String.Encoding.utf8) {
-                        formData.append(data, withName: key)
-                    }
+                default:
+                    str = "\(value)"
+                }
+                if let data = str.data(using: .utf8) {
+                    formData.append(data, withName: key)
                 }
             }
             formData.append(self.multipartData,


### PR DESCRIPTION
This fix allows using any types of parameter values with multipart requests.

The following will be possible:
```swift
let x: Int? = 42
let params: [AnyHashable: Any] = ["Int": 1, "Bool": true, "String": "X", "Double": 3.14, "Optional": x]
```
Note that it also handles optionals - the above will correctly output `"42"` rather than `"Optional(42)"`.
If the optional value is `nil`, this parameter will be omitted.

Resolves #43 