### PR TITLE
Add support for RequestAdapter

### DIFF
--- a/ws/WS.swift
+++ b/ws/WS.swift
@@ -46,7 +46,8 @@ open class WS {
     
     open var baseURL = ""
     open var headers = [String: String]()
-    
+    open var requestAdapter: RequestAdapter?
+
     /**
      Create a webservice instance.
      @param Pass the base url of your webservice, E.g : "http://jsonplaceholder.typicode.com"
@@ -73,6 +74,7 @@ open class WS {
         r.postParameterEncoding = postParameterEncoding
         r.showsNetworkActivityIndicator = showsNetworkActivityIndicator
         r.headers = headers
+        r.requestAdapter = requestAdapter
         r.errorHandler = errorHandler
         return r
     }


### PR DESCRIPTION
Addresses this issue: https://github.com/freshOS/ws/issues/61

RequestAdapter allows the client to make changes to the URL request before it goes out, so for example we can update the authentication token with a bearer token which changes frequently. 

new methods wsRequest() and wsUpdate are copies of the Alamofire methods except they set the request adapter - if any - before firing off the request. 

Alamofire 5 will have an asyncrhonous request adapter that will allow async calls to be made before requests are sent off, but this is still based on AF4.