### PR TITLE
Support for RequestRetrier and RequestAdapter

### DIFF
--- a/ws/WS.swift
+++ b/ws/WS.swift
@@ -46,7 +46,8 @@ open class WS {
     
     open var baseURL = ""
     open var headers = [String: String]()
-    
+    open var requestAdapter: RequestAdapter?
+
     /**
      Create a webservice instance.
      @param Pass the base url of your webservice, E.g : "http://jsonplaceholder.typicode.com"
@@ -73,6 +74,7 @@ open class WS {
         r.postParameterEncoding = postParameterEncoding
         r.showsNetworkActivityIndicator = showsNetworkActivityIndicator
         r.headers = headers
+        r.requestAdapter = requestAdapter
         r.errorHandler = errorHandler
         return r
     }

--- a/ws/WS.swift
+++ b/ws/WS.swift
@@ -47,6 +47,7 @@ open class WS {
     open var baseURL = ""
     open var headers = [String: String]()
     open var requestAdapter: RequestAdapter?
+    open var requestRetrier: RequestRetrier?
 
     /**
      Create a webservice instance.
@@ -75,6 +76,7 @@ open class WS {
         r.showsNetworkActivityIndicator = showsNetworkActivityIndicator
         r.headers = headers
         r.requestAdapter = requestAdapter
+        r.requestRetrier = requestRetrier
         r.errorHandler = errorHandler
         return r
     }


### PR DESCRIPTION
These classes make it easier to implement an OAuth token based authentication system

The changes are basically just taking AlamoFire's convenience methods and putting them inside ws so we can set retrier and adapter on the SessionManager object. 

See https://github.com/freshOS/ws/issues/61